### PR TITLE
Update log4j dependencies

### DIFF
--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -22,9 +22,20 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.20.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.20.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
[PDS-4442](https://keap.atlassian.net/browse/PDS-4442)

Due to a vulnerability described in [CVE-2019-17571](https://github.com/advisories/GHSA-2qrg-x229-3v8q), log4j v1.2.17 needs to be updated. 

v1.2.17 is the last of the v1 releases, and has been unsupported for some time. log4j v2 introduced significant changes in their API. Utilizing the [log4j v1 - v2 bridge adapter](https://logging.apache.org/log4j/2.x/manual/migration.html#option-1-use-the-log4j-1-x-bridge-log4j-1-2-api) to mantain compatibility with existing legacy code.

- Replaced log4j v1.2.17 dependency for the log4j v1 - v2 bridge adapter, and their required dependencies (log4j-api and log4j-core).
